### PR TITLE
fix stealth preview moving out of aura

### DIFF
--- a/ActivatableEquipment/AuraPreviewCache.cs
+++ b/ActivatableEquipment/AuraPreviewCache.cs
@@ -65,7 +65,7 @@ namespace CustomActivatableEquipment {
       List<AbstractActor> actors = movingActor.Combat.AllActors;
       //Log.LogWrite("RecalculateStealthPips\n");
       foreach(AbstractActor actor in actors) {
-        int pips = actor.StealthPipsCurrent;
+        int pips = actor.StealthPipsTotal;
         //Log.LogWrite(" "+actor.DisplayName+":"+pips+"\n");
         bool nofurthercalc = false;
         List<AuraPreview> auras = previewAurasAdded(actor);
@@ -110,7 +110,7 @@ namespace CustomActivatableEquipment {
         }
         if (nofurthercalc) {
           //Log.LogWrite(" no further calc\n");
-          stealthPipsPreview.Add(actor, pips); continue;
+          stealthPipsPreview.Add(actor, System.Math.Max(pips, 0)); continue;
         }
         auras = previewAurasRemoved(actor);
         foreach (AuraPreview aura in auras) {
@@ -149,7 +149,7 @@ namespace CustomActivatableEquipment {
             //Log.LogWrite("  pips altered:" + pips + "\n");
           }
         }
-        stealthPipsPreview.Add(actor, pips);
+        stealthPipsPreview.Add(actor, System.Math.Max(pips, 0));
       }
     }
     public int getStealthPipsPreview(AbstractActor unit) {


### PR DESCRIPTION
this one needs a little bit more explaining:
with the old code, moving out of a stealth reducing aura (like sensors) creates fake preview ghost charges.
this was preventing you from moving out of sensor range of a mech and shooting it the same turn (moving your sensor aura out of their range).
root cause is, that standing in that aura, the target has -1 stealth charges, but StealthPipsCurrent clamps it to 0.
then moving out of the aura correctly increases it by 1.

the clamp to 0 at the end is neccesary to avoid further bugs in the UI.